### PR TITLE
Update on the slider docs page.md

### DIFF
--- a/docs/core-fields/slider.md
+++ b/docs/core-fields/slider.md
@@ -21,7 +21,7 @@ and theme responsiveness!
 |resolution|int/float|`1`|Sets the value's decimal significance. Acceptable values are: `1`, `0.1`, `0.01`, `0.001`, `0.0001`, `0.00001`. Any improper value will default to `1`.|
 |float_mark|string|(decimal)|Sets the floating point marker to either `.` (decimal) or `,` (comma). Any other value will default to the decimal value.|
 |select2|array||Array of select2 arguments. For more information see the 'Constructor' section of the Select2 docs.  Only applies when `display_value` is set to `select`.|
-|output_units|string|`px`|Sets the unit to be generated in any set output.
+|output_unit|string|`px`|Sets the unit to be generated in any set output.
 
 ::: tip Also See
 - [Global Field Arguments](../configuration/fields/arguments.md)


### PR DESCRIPTION
Changing the slider arg key 'output_units'  to 'output_unit'
as I am working on ver 4.5.7,In the slider feild docs page I found a little typo in the   argument [ output_units ] it should be [ output_unit ] without the s 

When I use : 
'output_units'   => 'rem'
The output unit defaults to 'px'

while using 'output_unit'   => 'rem'
The output unit will be  'rem' as I set it